### PR TITLE
Improve emission perf

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 ----------------
 
 - Use Kinesis PutRecord API rather than PutRecords
+- Improve emission performance (concurrent PutRecord calls)
 
 
 0.1 (2016-04-14)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 0.2 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Use Kinesis PutRecord API rather than PutRecords
 
 
 0.1 (2016-04-14)

--- a/README.rst
+++ b/README.rst
@@ -37,12 +37,13 @@ Send records aggregated up to 100KB, 200ms and joined with '\\n':
    from kinesis_producer import KinesisProducer
 
    config = dict(
+       aws_region='us-east-1',
        buffer_size_limit=100000,
        buffer_time_limit=0.2,
+       kinesis_concurrency=1,
+       kinesis_max_retries=10,
        record_delimiter='\n',
        stream_name='KINESIS_STREAM_NAME',
-       kinesis_max_retries=3,
-       aws_region='us-east-1',
        )
 
    k = KinesisProducer(config=config)
@@ -57,12 +58,16 @@ Send records aggregated up to 100KB, 200ms and joined with '\\n':
 Config
 ======
 
-- ``stream_name``: Name of the Kinesis Stream
-- ``kinesis_max_retries``: Number of Kinesis put_records call attempt before giving up
-- ``aws_region``: AWS region for Kinesis calls
-- ``buffer_size_limit``: Approximative size limit for record aggregation
-- ``record_delimiter``: Delimiter for record aggregation
-- ``buffer_time_limit``: Approximative time limit for record aggregation
+:aws_region: AWS region for Kinesis calls
+:buffer_size_limit: Approximative size limit for record aggregation
+:buffer_time_limit: Approximative time limit for record aggregation
+:kinesis_concurrency:
+   Set the concurrency level for Kinesis calls. Set to 1 for no
+   concurrency. Set to 2 and more to use a thread pool.
+:kinesis_max_retries:
+   Number of Kinesis put_records call attempt before giving up
+:record_delimiter: Delimiter for record aggregation
+:stream_name: Name of the Kinesis Stream
 
 
 Copyright and license

--- a/kinesis_producer/client.py
+++ b/kinesis_producer/client.py
@@ -45,17 +45,18 @@ class Client(object):
         self.max_retries = config['kinesis_max_retries']
         self.connection = get_connection(config['aws_region'])
 
-    def put_records(self, records):
+    def put_record(self, record):
         """Send records to Kinesis API.
 
         Records is a list of tuple like (data, partition_key).
         """
-        records = [{'Data': r, 'PartitionKey': p} for r, p in records]
+        data, partition_key = record
 
-        log.debug('Sending records: %s', str(records)[:100])
+        log.debug('Sending record: %s', data[:100])
         try:
-            call_and_retry(self.connection.put_records, self.max_retries,
-                           StreamName=self.stream, Records=records)
+            call_and_retry(self.connection.put_record, self.max_retries,
+                           StreamName=self.stream, Data=data,
+                           PartitionKey=partition_key)
         except:
             log.exception('Failed to send records to Kinesis')
 

--- a/kinesis_producer/producer.py
+++ b/kinesis_producer/producer.py
@@ -6,7 +6,7 @@ from six.moves import queue
 from .sender import Sender
 from .accumulator import RecordAccumulator
 from .buffer import RawBuffer
-from .client import Client
+from .client import Client, ThreadPoolClient
 from .partitioner import random_partitioner
 from .constants import KINESIS_RECORD_MAX_SIZE
 
@@ -23,7 +23,10 @@ class KinesisProducer(object):
         self._closed = False
 
         accumulator = RecordAccumulator(RawBuffer, config)
-        client = Client(config)
+        if config['kinesis_concurrency'] == 1:
+            client = Client(config)
+        else:
+            client = ThreadPoolClient(config)
         self._sender = Sender(queue=self._queue,
                               accumulator=accumulator,
                               client=client,

--- a/kinesis_producer/sender.py
+++ b/kinesis_producer/sender.py
@@ -69,8 +69,7 @@ class Sender(threading.Thread):
         if record_data:
             log.debug('Flushing to client (length: %i)', len(record_data))
             record = (record_data, self._partitioner(record_data))
-            records = [record]
-            self._client.put_records(records)
+            self._client.put_record(record)
 
     def close(self):
         log.debug("Closing kinesis producer I/O thread")

--- a/test.py
+++ b/test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import logging
-# import time
+import time
 
 from kinesis_producer import KinesisProducer
 
@@ -11,25 +11,27 @@ logging.getLogger('botocore').setLevel(logging.WARNING)
 log = logging.getLogger(__name__)
 
 config = dict(
-    buffer_size_limit=100000,
+    aws_region='us-east-1',
+    buffer_size_limit=200000,
     buffer_time_limit=0.2,
+    kinesis_concurrency=4,
+    kinesis_max_retries=10,
     record_delimiter='\n',
     stream_name='jz-python-devlocal',
-    kinesis_max_retries=3,
-    aws_region='us-east-1',
     )
 
 k = KinesisProducer(config=config)
 
-payload = '{MSG:%%05i %s}' % ('BlaBl' * 198)
+payload = '{MSG:%%05i %s}' % ('X' * 1000)
 
 try:
     print ' <> MSGS'
-    for msg_id in range(1500):
+    for msg_id in range(50000):
         record = payload % msg_id
         k.send(record)
-        # time.sleep(0.0001)
+        # time.sleep(0.2)
 
+    # time.sleep(5)
 except KeyboardInterrupt:
     pass
 finally:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,12 +10,13 @@ TEST_STREAM_NAME = 'STREAM_NAME'
 @pytest.fixture(scope="module")
 def config():
     config = dict(
+        aws_region='us-east-1',
         buffer_size_limit=100,
         buffer_time_limit=0.2,
+        kinesis_concurrency=1,
+        kinesis_max_retries=3,
         record_delimiter=b'\n',
         stream_name=TEST_STREAM_NAME,
-        kinesis_max_retries=3,
-        aws_region='us-east-1',
     )
     return config
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -20,7 +20,7 @@ def test_close(kinesis, config):
     c.join()
 
 
-def test_send_records(kinesis):
+def test_send_record(kinesis):
     config = {
         'aws_region': 'us-east-1',
         'stream_name': 'STREAM_NAME',
@@ -28,18 +28,14 @@ def test_send_records(kinesis):
     }
     client = Client(config)
 
-    record1 = (b'data', 'part1')
-    record2 = (b'datadatadata', 'part2')
-    client.put_records([record1, record2])
+    record = (b'data', 'part')
+    client.put_record(record)
 
     records = kinesis.read_records_from_stream()
 
-    assert len(records) == 2
-    assert records[0]['PartitionKey'] == 'part1'
+    assert len(records) == 1
+    assert records[0]['PartitionKey'] == 'part'
     assert records[0]['Data'] == b'data'
-
-    assert records[1]['PartitionKey'] == 'part2'
-    assert records[1]['Data'] == b'datadatadata'
 
 
 def test_send_records_handle_error(config, kinesis):
@@ -48,9 +44,9 @@ def test_send_records_handle_error(config, kinesis):
     record = (b'data', 'part1')
 
     with mock.patch.object(client, 'connection') as m_conn:
-        m_conn.put_records.side_effect = Exception()
+        m_conn.put_record.side_effect = Exception()
 
-        client.put_records([record])
+        client.put_record(record)
 
 
 def test_retry_logic_call():

--- a/tests/test_producer.py
+++ b/tests/test_producer.py
@@ -76,3 +76,15 @@ def test_records_are_not_lost(kinesis, config):
     records = kinesis.read_records_from_stream()
     assert len(records) == 1
     assert records[0]['Data'] == b'-\n'
+
+
+def test_send_with_threadpool_client(kinesis, config):
+    config['kinesis_concurrency'] = 2
+    c = KinesisProducer(config)
+    c.send(b'-')
+    c.close()
+    c.join()
+
+    records = kinesis.read_records_from_stream()
+    assert len(records) == 1
+    assert records[0]['Data'] == b'-\n'

--- a/tests/test_sender.py
+++ b/tests/test_sender.py
@@ -32,13 +32,13 @@ def test_flush(config):
                     client=client, partitioner=partitioner)
 
     sender.flush()
-    assert not client.put_records.called
+    assert not client.put_record.called
 
     accumulator.try_append(b'-')
 
     sender.flush()
-    expected_records = [(b'-\n', 4)]
-    client.put_records.assert_called_once_with(expected_records)
+    expected_record = (b'-\n', 4)
+    client.put_record.assert_called_once_with(expected_record)
 
 
 def test_accumulate(config):
@@ -69,7 +69,7 @@ def test_flush_if_ready(config):
     accumulator.try_append(b'-' * 200)
     sender.run_once()
 
-    assert client.put_records.called
+    assert client.put_record.called
     assert not accumulator.has_records()
 
 
@@ -85,5 +85,5 @@ def test_flush_if_full(config):
     q.put(b'-' * 50)
     sender.run_once()
 
-    assert client.put_records.called
+    assert client.put_record.called
     assert accumulator.has_records()


### PR DESCRIPTION
This PR adds the ability to send Kinesis PutRecord calls in parallel. 

Also, the PutRecords call has been replaced by PutRecord since we send only one record at a time for now and PutRecords seems to partially handle the retry.
