### PR TITLE
Time start fix for accumulator

### DIFF
--- a/kinesis_producer/accumulator.py
+++ b/kinesis_producer/accumulator.py
@@ -16,7 +16,7 @@ class RecordAccumulator(object):
     def try_append(self, record):
         """Attempt to accumulate a record. Return False if buffer is full."""
         success = self._buffer.try_append(record)
-        if success:
+        if success and self._buffer_started_at is None:
             self._buffer_started_at = time.time()
         return success
 

--- a/tests/test_accumulator.py
+++ b/tests/test_accumulator.py
@@ -42,6 +42,7 @@ def test_append_timeout():
     acc = RecordAccumulator(RawBuffer, CONFIG)
     acc.try_append(b'-')
     time.sleep(0.2)
+    acc.try_append(b'-')
     assert acc.is_ready()
 
     acc.flush()


### PR DESCRIPTION
The buffer start time we record in the accumulator should be that of the first record, not that of the most recent record.